### PR TITLE
XT-422 rcp correlation ID

### DIFF
--- a/lib/railway_ipc.rb
+++ b/lib/railway_ipc.rb
@@ -1,7 +1,7 @@
 require "railway_ipc/version"
 require "sneakers"
 require "bunny"
-require "railway_ipc/version"
+require "securerandom"
 require "railway_ipc/logger"
 require "railway_ipc/unhandled_message_error"
 require "railway_ipc/response"

--- a/lib/railway_ipc/client.rb
+++ b/lib/railway_ipc/client.rb
@@ -42,6 +42,7 @@ module RailwayIpc
 
     def setup_reply_queue
       @reply_queue = channel.queue('', auto_delete: true, exclusive: true)
+      request_message.correlation_id = SecureRandom.uuid if request_message.correlation_id.empty?
       @call_id = request_message.correlation_id
       request_message.reply_to = reply_queue.name
     end

--- a/lib/railway_ipc/server.rb
+++ b/lib/railway_ipc/server.rb
@@ -37,9 +37,11 @@ module RailwayIpc
       begin
         response = work(payload)
       rescue StandardError => e
-        RailwayIpc.logger.error(message, "Error responding to message. Error: #{e.class}, #{e.message}")
+        RailwayIpc.logger.error(message, "Error responding to request. Error: #{e.class}, #{e.message}")
         response = self.rpc_error_adapter.error_message(e, message)
       ensure
+        response.correlation_id = message.correlation_id
+        RailwayIpc.logger.info(response, "Publishing response")
         exchange.publish(
           RailwayIpc::Rabbitmq::Payload.encode(response),
           routing_key: message.reply_to

--- a/spec/integration/request_response_spec.rb
+++ b/spec/integration/request_response_spec.rb
@@ -11,6 +11,17 @@ ISpec.describe "Request Response Cycle" do
       response = RailwayIpc::TestClient.request_documents("1234")
       response.body.is_a?(LearnIpc::Documents::TestDocument)
     end
+
+    ISpec.it "has a correlation ID" do
+      response = RailwayIpc::TestClient.request_documents("1234")
+      response.body.correlation_id != ""
+    end
+
+    ISpec.it "response has the same correlation ID as the request" do
+      uuid = SecureRandom.uuid
+      response = RailwayIpc::TestClient.request_documents_with_correlation_id("1234", uuid)
+      response.body.correlation_id == uuid
+    end
   end
 
   ISpec.context "when the server receives and unhandled message" do

--- a/spec/support/test_client.rb
+++ b/spec/support/test_client.rb
@@ -5,32 +5,34 @@ require_relative "./rpc_adapter.rb"
 require_relative "./timeout_request_pb.rb"
 require_relative "./error_message_pb"
 
- module RailwayIpc
-   class TestClient < RailwayIpc::Client
-     publish_to queue: "ipc:test:requests", exchange: "ipc:test:requests"
-     handle_response LearnIpc::Documents::TestDocument
-     rpc_error_adapter RailwayIpc::RpcAdapter
-     rpc_error_message LearnIpc::ErrorMessage
+module RailwayIpc
+  class TestClient < RailwayIpc::Client
+    publish_to queue: "ipc:test:requests", exchange: "ipc:test:requests"
+    handle_response LearnIpc::Documents::TestDocument
+    rpc_error_adapter RailwayIpc::RpcAdapter
+    rpc_error_message LearnIpc::ErrorMessage
 
-     def self.request_documents(user_uuid)
-       message = LearnIpc::Requests::TestRequest.new(
-         user_uuid: user_uuid,
-         correlation_id: "56789")
-       request(message)
-     end
+    def self.request_documents(user_uuid)
+      message = LearnIpc::Requests::TestRequest.new(user_uuid: user_uuid)
+      request(message)
+    end
 
-     def self.unhandled_message(user_uuid)
-       message = LearnIpc::Requests::UnhandledRequest.new(
-         user_uuid: user_uuid,
-         correlation_id: "56789")
-       request(message)
-     end
+    def self.request_documents_with_correlation_id(user_uuid, correlation_id)
+      message = LearnIpc::Requests::TestRequest.new(
+        user_uuid: user_uuid,
+        correlation_id: correlation_id
+      )
+      request(message)
+    end
 
-     def self.timeout_message(user_uuid)
-       message = LearnIpc::Requests::TimeoutRequest.new(
-         user_uuid: user_uuid,
-         correlation_id: "56789")
-       request(message)
-     end
-   end
- end
+    def self.unhandled_message(user_uuid)
+      message = LearnIpc::Requests::UnhandledRequest.new(user_uuid: user_uuid)
+      request(message)
+    end
+
+    def self.timeout_message(user_uuid)
+      message = LearnIpc::Requests::TimeoutRequest.new(user_uuid: user_uuid)
+      request(message)
+    end
+  end
+end


### PR DESCRIPTION
When sending an RPC request from a client
* Ensure that response document has the same correlation ID
* Ensure that a correlation ID gets added to the request before its published if that request doesn't already have one